### PR TITLE
linted ruby codes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
+gem 'jekyll'
 
-gem "jekyll"
-
-gem "minima", "~> 2.0"
+gem 'minima', '~> 2.0'
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
@@ -11,15 +10,15 @@ gem "minima", "~> 2.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem 'jekyll-redirect-from'
+  gem 'feedjira'
   gem 'jekyll-octicons'
   gem 'jekyll-readme-index'
+  gem 'jekyll-redirect-from'
   gem 'jemoji'
-  gem 'feedjira'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.0" if Gem.win_platform?
+gem 'wdm', '~> 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
@@ -25,6 +26,7 @@ GEM
       loofah (>= 2.0)
       sax-machine (>= 1.0)
     ffi (1.9.25)
+    ffi (1.9.25-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     html-pipeline (2.8.3)
@@ -84,6 +86,8 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.4-x64-mingw32)
+      mini_portile2 (~> 2.3.0)
     octicons (8.0.0)
       nokogiri (>= 1.6.3.1)
     pathutil (0.16.1)
@@ -104,9 +108,13 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2018.5)
+      tzinfo (>= 1.0.0)
+    wdm (0.1.1)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   feedjira
@@ -117,6 +125,7 @@ DEPENDENCIES
   jemoji
   minima (~> 2.0)
   tzinfo-data
+  wdm (~> 0.1.0)
 
 BUNDLED WITH
    1.16.2

--- a/_plugins/medium_post_display.rb
+++ b/_plugins/medium_post_display.rb
@@ -1,20 +1,22 @@
 require 'feedjira'
 module Jekyll
+  # Get RSS feed to the site
   class MediumPostDisplay < Generator
     safe true
     priority :high
-def generate(site)
+    def generate(site)
       jekyll_coll = Jekyll::Collection.new(site, 'external_feed')
       site.collections['external_feed'] = jekyll_coll
-Feedjira::Feed.fetch_and_parse("https://medium.com/feed/programming-society-gazette/").entries.each do |e|
-        title = e[:title]
-        content = e[:content]
-        guid = e[:url]
-        path = "./_external_feed/" + title + ".md"
-        path = site.in_source_dir(path)
-        doc = Jekyll::Document.new(path, { :site => site, :collection => jekyll_coll })
-        doc.data['title'] = title;
-        doc.data['feed_content'] = content;
+      display(jekyll_coll, site)
+    end
+
+    def display(jekyll_coll, site)
+      Feedjira::Feed.fetch_and_parse('https://medium.com/feed/programming-society-gazette/')
+                    .entries.each do |e|
+        path = site.in_source_dir('./_external_feed/' + e[:title] + '.md')
+        doc = Jekyll::Document.new(path, site: site, collection: jekyll_coll)
+        doc.data['title'] = e[:title]
+        doc.data['feed_content'] = e[:content]
         jekyll_coll.docs << doc
       end
     end


### PR DESCRIPTION
fixes #36 
Used https://github.com/rubocop-hq/rubocop for linting.

Fix Preview:
![image](https://user-images.githubusercontent.com/33368759/43276960-2f7e400e-9124-11e8-939d-176043a9c2dd.png)

